### PR TITLE
Add unit tests for core logic

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dev_dependencies:
   json_serializable: ^6.9.5
   flutter_test:
     sdk: flutter
+  mocktail: ^1.0.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/unit_tests/datasources/auth_local_datasource_test.dart
+++ b/test/unit_tests/datasources/auth_local_datasource_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:dtoro/features/auth/data/datasources/auth_local_datasource.dart';
+import 'package:dtoro/features/user/domain/entities/user_entity.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLocalDataSourceImpl dataSource;
+
+  const user = UserEntity(
+    id: 'u1',
+    displayName: 'User',
+    email: 'a',
+    role: UserRole.chef,
+    companyId: 'c1',
+    createdAt: DateTime.utc(2024, 1, 1),
+  );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    dataSource = AuthLocalDataSourceImpl(prefs);
+  });
+
+  test('cache and retrieve user', () async {
+    await dataSource.cacheUser(user);
+    final result = await dataSource.getCachedUser();
+    expect(result, user);
+  });
+
+  test('clearCache removes data', () async {
+    await dataSource.cacheUser(user);
+    await dataSource.clearCache();
+    final result = await dataSource.getCachedUser();
+    expect(result, isNull);
+  });
+}

--- a/test/unit_tests/models/cart_item_model_test.dart
+++ b/test/unit_tests/models/cart_item_model_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dtoro/features/cart/data/models/cart_item_model.dart';
+
+void main() {
+  group('CartItemModel', () {
+    test('create uses sellerProductId as id', () {
+      final model = CartItemModel.create(sellerProductId: 'sp1', quantity: 2);
+      expect(model.id, 'sp1');
+      expect(model.sellerProductId, 'sp1');
+      expect(model.quantity, 2);
+    });
+
+    test('toEntity converts correctly', () {
+      const model = CartItemModel(id: 'sp1', sellerProductId: 'sp1', quantity: 3);
+      final entity = model.toEntity();
+      expect(entity.sellerProductId, 'sp1');
+      expect(entity.quantity, 3);
+    });
+  });
+}

--- a/test/unit_tests/models/cart_model_test.dart
+++ b/test/unit_tests/models/cart_model_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dtoro/features/cart/data/models/cart_model.dart';
+import 'package:dtoro/features/cart/domain/entities/cart_status.dart';
+
+void main() {
+  group('CartModel', () {
+    test('create sets id using userId and status', () {
+      final model = CartModel.create(userId: 'u1', zoneId: 'z1');
+      expect(model.id, 'u1_active');
+      expect(model.status, CartStatus.active);
+    });
+
+    test('toEntity converts correctly', () {
+      final ts = Timestamp.now();
+      final model = CartModel(
+        id: 'u1_active',
+        userId: 'u1',
+        zoneId: 'z1',
+        status: CartStatus.active,
+        updatedAt: ts,
+      );
+      final entity = model.toEntity();
+      expect(entity.id, model.id);
+      expect(entity.userId, model.userId);
+      expect(entity.zoneId, model.zoneId);
+      expect(entity.status, CartStatusEntity.active);
+      expect(entity.updatedAt, ts.toDate());
+    });
+  });
+}

--- a/test/unit_tests/models/user_model_test.dart
+++ b/test/unit_tests/models/user_model_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dtoro/features/auth/data/models/user_model.dart';
+import 'package:dtoro/features/user/domain/entities/user_entity.dart';
+
+void main() {
+  group('UserModel', () {
+    const userEntity = UserEntity(
+      id: 'u1',
+      displayName: 'Test',
+      email: 'test@example.com',
+      role: UserRole.chef,
+      companyId: 'c1',
+      createdAt: DateTime.utc(2024, 1, 1),
+    );
+
+    test('fromEntity and toEntity are symmetric', () {
+      final model = UserModel.fromEntity(userEntity);
+      expect(model.toEntity(), equals(userEntity));
+    });
+
+    test('toJson and fromJson are symmetric', () {
+      final model = UserModel.fromEntity(userEntity);
+      final json = model.toJson();
+      final rebuilt = UserModel.fromJson(json);
+      expect(rebuilt, equals(model));
+    });
+  });
+}

--- a/test/unit_tests/repositories/cart_repository_impl_test.dart
+++ b/test/unit_tests/repositories/cart_repository_impl_test.dart
@@ -1,0 +1,133 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:dtoro/features/cart/data/repositories/cart_repository_impl.dart';
+import 'package:dtoro/features/cart/data/datasources/cart_remote_datasource.dart';
+import 'package:dtoro/core/network/network_info.dart';
+import 'package:dtoro/features/catalog/domain/entities/product_reference.dart';
+import 'package:dtoro/features/catalog/domain/entities/best_price.dart';
+import 'package:dtoro/core/enums/unit_type.dart';
+import 'package:dtoro/features/catalog/domain/entities/catalog_state.dart';
+import 'package:dtoro/features/cart/domain/entities/cart_item.dart';
+
+class MockRemote extends Mock implements CartRemoteDataSource {}
+class MockNetworkInfo extends Mock implements NetworkInfo {}
+
+void main() {
+  late CartRepositoryImpl repository;
+
+  setUp(() {
+    repository = CartRepositoryImpl(
+      remoteDataSource: MockRemote(),
+      networkInfo: MockNetworkInfo(),
+    );
+  });
+
+  group('calculateTotal', () {
+    test('returns correct total', () {
+      final products = [
+        ProductReference(
+          id: 'p1',
+          name: 'A',
+          description: '',
+          imageUrl: '',
+          unitType: UnitType.kg,
+          catalogPriority: 1,
+          catalogState: CatalogState.approved,
+          bestPrice: const BestPrice(
+            sellerId: 's1',
+            sellerName: 'S1',
+            sellerProductId: 'sp1',
+            price: 2.5,
+            currency: 'USD',
+            zoneId: 'z1',
+          ),
+          label: null,
+        ),
+        ProductReference(
+          id: 'p2',
+          name: 'B',
+          description: '',
+          imageUrl: '',
+          unitType: UnitType.piece,
+          catalogPriority: 1,
+          catalogState: CatalogState.approved,
+          bestPrice: const BestPrice(
+            sellerId: 's2',
+            sellerName: 'S2',
+            sellerProductId: 'sp2',
+            price: 4.0,
+            currency: 'USD',
+            zoneId: 'z1',
+          ),
+          label: null,
+        ),
+      ];
+      final items = [
+        const CartItem(sellerProductId: 'sp1', quantity: 2),
+        const CartItem(sellerProductId: 'sp2', quantity: 1),
+      ];
+      final total = repository.calculateTotal(items, products);
+      expect(total, closeTo(2 * 2.5 + 1 * 4.0, 0.001));
+    });
+  });
+
+  group('groupItemsBySeller', () {
+    test('groups items by sellerId', () {
+      final products = [
+        ProductReference(
+          id: 'p1',
+          name: 'A',
+          description: '',
+          imageUrl: '',
+          unitType: UnitType.kg,
+          catalogPriority: 1,
+          catalogState: CatalogState.approved,
+          bestPrice: const BestPrice(
+            sellerId: 's1',
+            sellerName: 'S1',
+            sellerProductId: 'sp1',
+            price: 2.5,
+            currency: 'USD',
+            zoneId: 'z1',
+          ),
+          label: null,
+        ),
+        ProductReference(
+          id: 'p2',
+          name: 'B',
+          description: '',
+          imageUrl: '',
+          unitType: UnitType.kg,
+          catalogPriority: 1,
+          catalogState: CatalogState.approved,
+          bestPrice: const BestPrice(
+            sellerId: 's1',
+            sellerName: 'S1',
+            sellerProductId: 'sp2',
+            price: 1.0,
+            currency: 'USD',
+            zoneId: 'z1',
+          ),
+          label: null,
+        ),
+      ];
+      final items = [
+        const CartItem(sellerProductId: 'sp1', quantity: 1),
+        const CartItem(sellerProductId: 'sp2', quantity: 3),
+      ];
+      final grouped = repository.groupItemsBySeller(items, products);
+      expect(grouped.keys, contains('s1'));
+      expect(grouped['s1']!.length, 2);
+    });
+  });
+
+  group('formatPrice', () {
+    test('formats according to unit type', () {
+      expect(repository.formatPrice(1.5, 'kg'), '\$1.50 / kg');
+      expect(repository.formatPrice(2, 'lb'), '\$2.00 / lb');
+      expect(repository.formatPrice(3, 'piece'), '\$3.00 / each');
+      expect(repository.formatPrice(4, 'unknown'), '\$4.00');
+    });
+  });
+}

--- a/test/unit_tests/usecases/auth_usecases_test.dart
+++ b/test/unit_tests/usecases/auth_usecases_test.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:dtoro/features/auth/domain/usecases/sign_in_usecase.dart';
+import 'package:dtoro/features/auth/domain/usecases/sign_out_usecase.dart';
+import 'package:dtoro/features/auth/domain/usecases/get_auth_state_usecase.dart';
+import 'package:dtoro/features/auth/domain/repositories/auth_repository.dart';
+import 'package:dtoro/features/auth/domain/entities/login_request.dart';
+import 'package:dtoro/features/auth/domain/entities/auth_state.dart';
+import 'package:dtoro/features/user/domain/entities/user_entity.dart';
+import 'package:dtoro/core/usecases/usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late MockAuthRepository repository;
+  late SignInUseCase signIn;
+  late SignOutUseCase signOut;
+  late GetAuthStateUseCase getAuthState;
+
+  setUp(() {
+    repository = MockAuthRepository();
+    signIn = SignInUseCase(repository);
+    signOut = SignOutUseCase(repository);
+    getAuthState = GetAuthStateUseCase(repository);
+  });
+
+  test('SignInUseCase forwards call to repository', () async {
+    final request = const LoginRequest(email: 'a', password: 'b');
+    final user = UserEntity(
+      id: 'u1',
+      displayName: 'User',
+      email: 'a',
+      role: UserRole.chef,
+      createdAt: DateTime.now(),
+    );
+    when(() => repository.signInWithEmailAndPassword(request))
+        .thenAnswer((_) async => user);
+    final result = await signIn(request);
+    expect(result, user);
+    verify(() => repository.signInWithEmailAndPassword(request)).called(1);
+  });
+
+  test('SignOutUseCase forwards call to repository', () async {
+    when(() => repository.signOut()).thenAnswer((_) async {});
+    await signOut(const NoParams());
+    verify(() => repository.signOut()).called(1);
+  });
+
+  test('GetAuthStateUseCase returns stream from repository', () {
+    final controller = StreamController<AuthState>();
+    when(() => repository.authStateStream).thenAnswer((_) => controller.stream);
+    expect(getAuthState(), controller.stream);
+  });
+}


### PR DESCRIPTION
## Summary
- add `mocktail` for creating mocks in tests
- cover data models with tests
- cover repository helpers with tests
- add tests for auth use cases and datasource

## Testing
- `dart pub get` *(fails: Flutter SDK not available)*
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_b_68842c05d9d483328f079bc953d4be50